### PR TITLE
Support multi-domain base URL configuration

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -12,6 +12,7 @@ TAVILY_API_KEY=[YOUR_TAVILY_API_KEY]  # Get your API key at: https://app.tavily.
 
 # Optional Docker Configuration (only needed in some Docker environments)
 # BASE_URL=http://localhost:3000  # Use only if models.json fails to load in Docker
+# BASE_URL=https://traceremove.com,https://traceremove.net  # Multi-domain deployments support comma-separated URLs
 
 ###############################################################################
 # Optional Features

--- a/README.md
+++ b/README.md
@@ -157,6 +157,9 @@ Visit http://localhost:3000 in your browser.
 ## 🌐 Deploy
 
 Host your own live version of Morphic with Vercel, Cloudflare Pages, or Docker.
+If you plan to serve the same deployment from multiple domains, configure the
+`BASE_URL` environment variable as described in the
+[Configuration Guide](docs/CONFIGURATION.md#base-url--multi-domain-deployments).
 
 ### Vercel
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -5,6 +5,7 @@ This guide covers the optional features and their configuration in Morphic.
 ## Table of Contents
 
 - [Chat History Storage](#chat-history-storage)
+- [Base URL & Multi-domain Deployments](#base-url--multi-domain-deployments)
 - [Search Providers](#search-providers)
 - [Additional AI Providers](#additional-ai-providers)
 - [Other Features](#other-features)
@@ -224,3 +225,23 @@ SERPER_API_KEY=[YOUR_API_KEY]
 ```bash
 JINA_API_KEY=[YOUR_API_KEY]
 ```
+## Base URL & Multi-domain Deployments
+
+Use the `BASE_URL` (or `NEXT_PUBLIC_BASE_URL`) environment variable when you
+need to override the automatically detected host—for example, when the app is
+served behind a proxy or during static rendering. The value now supports a
+comma-separated list of canonical URLs, which is useful when deploying the same
+instance across multiple domains.
+
+```bash
+# Example: serve Morphic from multiple domains
+BASE_URL=https://traceremove.com,https://traceremove.net,https://traceremove.dev
+```
+
+At runtime Morphic compares the incoming request host against each configured
+URL and picks the matching one. If no match is found it falls back to the first
+entry, and finally to the host reported by Next.js headers. This ensures that
+features relying on absolute URLs—such as advanced SearXNG searches, shareable
+chat links, and model configuration—continue to work correctly on every mapped
+domain.
+

--- a/lib/utils/url.ts
+++ b/lib/utils/url.ts
@@ -1,11 +1,24 @@
 import { headers } from 'next/headers'
 
+function parseBaseUrlCandidates(baseUrlEnv: string | undefined) {
+  if (!baseUrlEnv) {
+    return [] as string[]
+  }
+
+  return baseUrlEnv
+    .split(',')
+    .map(candidate => candidate.trim())
+    .filter(candidate => candidate.length > 0)
+}
+
 /**
  * Helper function to get base URL from headers
  * Extracts URL information from Next.js request headers
  */
-export async function getBaseUrlFromHeaders(): Promise<URL> {
-  const headersList = await headers()
+export async function getBaseUrlFromHeaders(
+  providedHeaders?: Headers
+): Promise<URL> {
+  const headersList = providedHeaders ?? (await headers())
   const baseUrl = headersList.get('x-base-url')
   const url = headersList.get('x-url')
   const host = headersList.get('x-host')
@@ -37,24 +50,46 @@ export async function getBaseUrlFromHeaders(): Promise<URL> {
  * @returns A URL object representing the base URL
  */
 export async function getBaseUrl(): Promise<URL> {
+  const headersList = await headers()
+  const hostFromHeaders =
+    headersList.get('x-host') || headersList.get('host') || undefined
+
   // Check for environment variables first
   const baseUrlEnv = process.env.NEXT_PUBLIC_BASE_URL || process.env.BASE_URL
+  const baseUrlCandidates = parseBaseUrlCandidates(baseUrlEnv)
 
-  if (baseUrlEnv) {
+  if (baseUrlCandidates.length > 0) {
+    const matchingCandidate = baseUrlCandidates.find(candidate => {
+      try {
+        const parsedCandidate = new URL(candidate)
+        return hostFromHeaders
+          ? parsedCandidate.host === hostFromHeaders
+          : false
+      } catch (error) {
+        console.warn(
+          `Invalid BASE_URL candidate "${candidate}". Ignoring this value.`
+        )
+        return false
+      }
+    })
+
+    if (matchingCandidate) {
+      console.log('Using BASE_URL matched to host:', matchingCandidate)
+      return new URL(matchingCandidate)
+    }
+
     try {
-      const baseUrlObj = new URL(baseUrlEnv)
-      console.log('Using BASE_URL environment variable:', baseUrlEnv)
-      return baseUrlObj
+      console.log('Using BASE_URL environment variable:', baseUrlCandidates[0])
+      return new URL(baseUrlCandidates[0])
     } catch (error) {
       console.warn(
         'Invalid BASE_URL environment variable, falling back to headers'
       )
-      // Fall back to headers if the environment variable is invalid
     }
   }
 
   // If no valid environment variable is available, use headers
-  return await getBaseUrlFromHeaders()
+  return await getBaseUrlFromHeaders(headersList)
 }
 
 /**


### PR DESCRIPTION
## Summary
- allow BASE_URL environment variables to define multiple comma-separated domains and pick the right one at runtime
- document the multi-domain setup in the configuration guide and reference it from the README
- update the example environment file with guidance for multi-domain deployments

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_e_68da61672ba08325b041ab03774a3198