### PR TITLE
Add tests for base URL utilities

### DIFF
--- a/bun-test.d.ts
+++ b/bun-test.d.ts
@@ -1,0 +1,10 @@
+declare module 'bun:test' {
+  export const describe: (...args: any[]) => void
+  export const it: (...args: any[]) => void
+  export const expect: (...args: any[]) => any
+  export const beforeAll: (...args: any[]) => void
+  export const afterEach: (...args: any[]) => void
+  export const mock: {
+    module: (specifier: string, factory: () => Record<string, unknown>) => void
+  }
+}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -225,6 +225,7 @@ SERPER_API_KEY=[YOUR_API_KEY]
 ```bash
 JINA_API_KEY=[YOUR_API_KEY]
 ```
+
 ## Base URL & Multi-domain Deployments
 
 Use the `BASE_URL` (or `NEXT_PUBLIC_BASE_URL`) environment variable when you
@@ -268,4 +269,3 @@ object, or even a plain header record when resolving URLs during background
 tasks. If you need to change `BASE_URL`-related environment variables between
 tests, call `resetBaseUrlCache()` from the same module so subsequent assertions
 pick up the updated values.
-

--- a/lib/utils/url.test.ts
+++ b/lib/utils/url.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeAll, describe, expect, it, mock } from 'bun:test'
+
+mock.module('next/headers', () => ({
+  headers: () => new Headers()
+}))
+
+type UrlModule = typeof import('./url')
+
+let getBaseUrl: UrlModule['getBaseUrl']
+let getBaseUrlFromHeaders: UrlModule['getBaseUrlFromHeaders']
+let getBaseUrlString: UrlModule['getBaseUrlString']
+let resetBaseUrlCache: UrlModule['resetBaseUrlCache']
+
+const ORIGINAL_ENV = { ...process.env }
+
+function restoreEnv() {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in ORIGINAL_ENV)) {
+      delete process.env[key]
+    }
+  }
+
+  for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+}
+
+beforeAll(async () => {
+  const urlModule = await import('./url')
+  getBaseUrl = urlModule.getBaseUrl
+  getBaseUrlFromHeaders = urlModule.getBaseUrlFromHeaders
+  getBaseUrlString = urlModule.getBaseUrlString
+  resetBaseUrlCache = urlModule.resetBaseUrlCache
+})
+
+afterEach(() => {
+  restoreEnv()
+  resetBaseUrlCache()
+})
+
+describe('getBaseUrl utilities', () => {
+  it('falls back to the local development URL when no hints are present', async () => {
+    delete process.env.BASE_URL
+    delete process.env.NEXT_PUBLIC_BASE_URL
+    delete process.env.VERCEL_URL
+    delete process.env.NEXT_PUBLIC_VERCEL_URL
+
+    const resolved = await getBaseUrl()
+
+    expect(resolved.toString()).toBe('http://localhost:3000/')
+  })
+
+  it('prefers the first configured BASE_URL candidate when no headers match', async () => {
+    process.env.BASE_URL = 'https://example.test, https://secondary.test'
+
+    const resolved = await getBaseUrlString()
+
+    expect(resolved).toBe('https://example.test/')
+  })
+
+  it('honours the explicit x-base-url header over other sources', async () => {
+    const headers = new Headers({
+      'x-base-url': 'https://header.example/path?q=1',
+      host: 'ignored.test'
+    })
+
+    const resolvedFromHeaders = await getBaseUrlFromHeaders(headers)
+    expect(resolvedFromHeaders.toString()).toBe(
+      'https://header.example/path?q=1'
+    )
+  })
+
+  it('constructs a URL from host and protocol headers when provided', async () => {
+    const headers = new Headers({
+      host: 'forwarded.example',
+      'x-forwarded-proto': 'https'
+    })
+
+    const resolved = await getBaseUrl(headers)
+
+    expect(resolved.toString()).toBe('https://forwarded.example/')
+  })
+
+  it('allows environment changes to be observed after resetting cached state', async () => {
+    process.env.BASE_URL = 'https://first.example'
+    await getBaseUrlString()
+
+    process.env.BASE_URL = 'https://second.example'
+
+    resetBaseUrlCache()
+    const updated = await getBaseUrlString()
+
+    expect(updated).toBe('https://second.example/')
+  })
+})

--- a/lib/utils/url.ts
+++ b/lib/utils/url.ts
@@ -61,7 +61,9 @@ function hasHeadersProperty(value: unknown): value is { headers: unknown } {
   )
 }
 
-function toHeaderLike(value: HeaderSource | null | undefined): HeaderLike | undefined {
+function toHeaderLike(
+  value: HeaderSource | null | undefined
+): HeaderLike | undefined {
   if (!value) {
     return undefined
   }
@@ -203,7 +205,7 @@ function normaliseHostValue(host?: string | null): NormalisedHost | undefined {
     const parsed = new URL(`http://${primaryHost}`)
     return {
       host: parsed.host.toLowerCase(),
-      hostname: parsed.hostname.toLowerCase(),
+      hostname: parsed.hostname.toLowerCase()
     }
   } catch {
     const trimmed = primaryHost.trim().toLowerCase()
@@ -215,7 +217,7 @@ function normaliseHostValue(host?: string | null): NormalisedHost | undefined {
     const [hostname] = trimmed.split(':')
     return {
       host: trimmed,
-      hostname,
+      hostname
     }
   }
 }
@@ -303,9 +305,7 @@ function readDeploymentUrl(): URL | undefined {
       return undefined
     }
 
-    const candidate = trimmed.includes('://')
-      ? trimmed
-      : `https://${trimmed}`
+    const candidate = trimmed.includes('://') ? trimmed : `https://${trimmed}`
 
     const parsed = new URL(candidate)
 
@@ -395,7 +395,10 @@ function constructUrlFromHost(
   try {
     return new URL(`${effectiveProtocol}://${host.host}`)
   } catch (error) {
-    console.warn('Unable to construct base URL from headers. Falling back.', error)
+    console.warn(
+      'Unable to construct base URL from headers. Falling back.',
+      error
+    )
     return undefined
   }
 }
@@ -433,12 +436,13 @@ function resolveHeaderContext(headersList: HeaderLike): ResolvedHeaderContext {
     takePrimaryHeaderValue(headersList.get('x-host')) ||
     takePrimaryHeaderValue(headersList.get('host'))
 
-  const host = mergeHostAndPort(rawHost, forwardedPort, normalisedProtocol) || rawHost
+  const host =
+    mergeHostAndPort(rawHost, forwardedPort, normalisedProtocol) || rawHost
 
   return {
     directUrl,
     host: normaliseHostValue(host),
-    protocol: normalisedProtocol,
+    protocol: normalisedProtocol
   }
 }
 
@@ -470,7 +474,9 @@ function resolveUrlFromContext(
 
   return (
     context.directUrl ??
-    (contextHost ? constructUrlFromHost(contextHost, context.protocol) : undefined)
+    (contextHost
+      ? constructUrlFromHost(contextHost, context.protocol)
+      : undefined)
   )
 }
 
@@ -550,7 +556,7 @@ export async function getBaseUrlFromHeaders(
   providedHeaders?: MaybePromise<HeaderSource | null | undefined>
 ): Promise<URL> {
   const context = await resolveHeaderContextFromSources(providedHeaders, {
-    fallbackToNext: true,
+    fallbackToNext: true
   })
 
   const hostContext = context?.host
@@ -558,7 +564,9 @@ export async function getBaseUrlFromHeaders(
 
   return (
     context?.directUrl ??
-    (hostContext ? constructUrlFromHost(hostContext, context?.protocol) : undefined) ??
+    (hostContext
+      ? constructUrlFromHost(hostContext, context?.protocol)
+      : undefined) ??
     deploymentUrl ??
     fallbackBaseUrl()
   )
@@ -575,9 +583,12 @@ export async function getBaseUrl(
 ): Promise<URL> {
   const candidates = readBaseUrlCandidates()
   const deploymentUrl = readDeploymentUrl()
-  const initialContext = await resolveHeaderContextFromSources(providedHeaders, {
-    fallbackToNext: false,
-  })
+  const initialContext = await resolveHeaderContextFromSources(
+    providedHeaders,
+    {
+      fallbackToNext: false
+    }
+  )
 
   const initialResolved = resolveUrlFromContext(initialContext, candidates)
   if (initialResolved) {
@@ -585,7 +596,7 @@ export async function getBaseUrl(
   }
 
   const nextContext = await resolveHeaderContextFromSources(undefined, {
-    fallbackToNext: true,
+    fallbackToNext: true
   })
 
   const nextResolved = resolveUrlFromContext(nextContext, candidates)


### PR DESCRIPTION
## Summary
- add a lightweight bun:test module declaration so TypeScript understands the Bun testing APIs
- add Bun tests that exercise the base URL resolution helpers across header, environment, and cache reset scenarios
- format the base URL utility module and configuration guide with the repository Prettier settings

## Testing
- `bun test`
- `bun lint`
- `bun typecheck`
- `bun format:check`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_68dd55f009588325b27bca29668e1186